### PR TITLE
feat: budget for groups

### DIFF
--- a/src/cmd/solve.go
+++ b/src/cmd/solve.go
@@ -42,7 +42,7 @@ var solveCmd = &cobra.Command{
 		form := forms.GetForm(conf)
 
 		// Create a graph
-		g, sink := graph.Translate(form)
+		g, sink, _ := graph.Translate(form)
 
 		groups := form.Participant_count
 
@@ -101,7 +101,8 @@ func debugGraphBuilder() []graph.Edge {
 
 	return g
 }
-//TODO: Figure out what format the output will be finialized in and save it to a file
+
+// TODO: Figure out what format the output will be finialized in and save it to a file
 func SaveSolution() {
 
 }

--- a/src/cmd/solve.go
+++ b/src/cmd/solve.go
@@ -60,9 +60,9 @@ var solveCmd = &cobra.Command{
 			}
 		}
 
-		cost = ((cost - groups) - len(paths))
+		//cost_new := ((cost - float64(groups)) - float64(len(paths)))
 
-		println("Min cost: ", cost)
+		println("Min cost:", int(cost), "≈",cost)
 
 	},
 }

--- a/src/graph/graph_test.go
+++ b/src/graph/graph_test.go
@@ -26,28 +26,26 @@ func debugGraphBuilder() []graph.Edge {
 	// Groups -> 1, 2, 3
 	// Timeslots -> 4, 5, 6, 7
 	// Add edges to the graph
-	g = append(g, graph.Edge{From: 0, To: 1, Capacity: 100, Cost: 1})
-	g = append(g, graph.Edge{From: 0, To: 2, Capacity: 100, Cost: 1})
-	g = append(g, graph.Edge{From: 0, To: 3, Capacity: 100, Cost: 1})
+	g = append(g, graph.Edge{From: 0, To: 1, Capacity: 1, Cost: 0})
+	g = append(g, graph.Edge{From: 0, To: 2, Capacity: 1, Cost: 0})
+	g = append(g, graph.Edge{From: 0, To: 3, Capacity: 1, Cost: 0})
 
 	g = append(g, graph.Edge{From: 1, To: 4, Capacity: 1, Cost: 1})
 	g = append(g, graph.Edge{From: 2, To: 4, Capacity: 1, Cost: 1})
-	g = append(g, graph.Edge{From: 2, To: 5, Capacity: 2, Cost: 2})
-	g = append(g, graph.Edge{From: 3, To: 6, Capacity: 3, Cost: 3})
+	g = append(g, graph.Edge{From: 2, To: 5, Capacity: 1, Cost: 2})
+	g = append(g, graph.Edge{From: 3, To: 6, Capacity: 1, Cost: 3})
 	g = append(g, graph.Edge{From: 3, To: 7, Capacity: 1, Cost: 1})
 
-	g = append(g, graph.Edge{From: 4, To: 8, Capacity: 1, Cost: 1})
-	g = append(g, graph.Edge{From: 5, To: 8, Capacity: 1, Cost: 1})
-	g = append(g, graph.Edge{From: 6, To: 8, Capacity: 1, Cost: 1})
-	g = append(g, graph.Edge{From: 7, To: 8, Capacity: 1, Cost: 1})
+	g = append(g, graph.Edge{From: 4, To: 8, Capacity: 1, Cost: 0})
+	g = append(g, graph.Edge{From: 5, To: 8, Capacity: 1, Cost: 0})
+	g = append(g, graph.Edge{From: 6, To: 8, Capacity: 1, Cost: 0})
+	g = append(g, graph.Edge{From: 7, To: 8, Capacity: 1, Cost: 0})
 
 	return g
 }
 
 func TestMinCost(t *testing.T) {
 	g := debugGraphBuilder()
-
-	groups := 3
 
 	// Values are:
 	// 9 nodes, 3 is minimum flow required, 0 is source, 8 is sink, g is the graph
@@ -78,8 +76,8 @@ func TestMinCost(t *testing.T) {
 	}
 
 	// Check cost
-	cost = ((cost - groups) - len(paths))
-	if cost != 4 {
+
+	if int(cost) != 4 {
 		t.Error("Expected 4 cost, got", cost)
 	}
 
@@ -98,7 +96,7 @@ func TestGraphTranslation(t *testing.T) {
 	}
 
 	// Create a graph from form
-	g, sink := graph.Translate(form)
+	g, sink, _ := graph.Translate(form)
 
 	// Check number of edges
 	if len(g) != 18 {

--- a/src/graph/graph_translater.go
+++ b/src/graph/graph_translater.go
@@ -1,9 +1,8 @@
 package graph
 
 import (
-	"math/rand"
+	"sort"
 	"strings"
-	"time"
 
 	"github.com/Slug-Boi/aion-cli/forms"
 )
@@ -49,20 +48,36 @@ func Translate(data forms.Form) ([]Edge, int, map[int]User) {
 		// Add edge from source to participant
 		graph = append(graph, Edge{From: 0, To: userNodeInc, Capacity: 1, Cost: 0})
 
+
+		// These variables are used to keep track of the total budget of the group
+		// And the amount of leftovers nodes once we hit "red" timeslots 
+		// The list is sorted so we know all worst timeslots will be at the end
+		budget := 50.0
+		leftovers := 0.0
+
+		sort.Slice(participant.Votes, func(i, j int) bool {
+			return participant.Votes[i] > participant.Votes[j]
+		})
+
 		// Translate timeslots to participant linked nodes
-		for _, timeslot := range participant.Votes {
+		for j, timeslot := range participant.Votes {
+
 			// Add edge from participant to timeslot
 			var cap float64
+
 			if timeslot == 0 {
-				cap = 5.0
+				// Calculate the divider for the budget based on the amount of timeslots left
+				if leftovers == 0 {
+					leftovers = float64(len(participant.Votes)-j)
+				}
+				cap = (budget / leftovers)
 			} else if timeslot == 2 {
-				cap = 3.0
+				cap = 5.0
+				budget = budget - 5.0
 			} else {
-				cap = 1.0
+				cap = 0.0
 			}
-			if cap == cap+floats[i] {
-				println("yes")
-			}
+
 			graph = append(graph, Edge{From: userNodeInc, To: timeslotNodeInc, Capacity: 1, Cost: cap + floats[i]})
 			timeslotNodeInc++
 		}
@@ -76,17 +91,4 @@ func Translate(data forms.Form) ([]Edge, int, map[int]User) {
 		graph = append(graph, Edge{From: i, To: timeslotNodeInc, Capacity: 1, Cost: 0})
 	}
 	return graph, timeslotNodeInc, nodeToUser
-}
-
-// https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-go
-var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-
-func randSeq(n int) string {
-	rand.Seed(time.Now().UnixNano())
-
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
-	}
-	return string(b)
 }

--- a/src/graph/graph_translater.go
+++ b/src/graph/graph_translater.go
@@ -1,7 +1,9 @@
 package graph
 
 import (
+	"math/rand"
 	"strings"
+	"time"
 
 	"github.com/Slug-Boi/aion-cli/forms"
 )
@@ -21,8 +23,17 @@ func Translate(data forms.Form) ([]Edge, int, map[int]User) {
 
 	// Create heuristics for tie breaker
 	sb := strings.Builder{}
-	for i := 1; i < data.Participant_count; i++ {
-		sb.WriteString(strings.Split(data.PollResults[i].Name, "")[1])
+	for i := 0; i < data.Participant_count; i++ {
+		//TODO: Probably redo this to be more modular
+		split := strings.Fields(data.PollResults[i].Name)
+		if len(split) > 1 {
+			//TODO: Add a regex check for valid characters
+			sb.WriteString(split[1])
+		} else {
+			// If no string is provided then use their id as it is a pseudo random string
+			// that will result in the same value each time
+			sb.WriteString(data.PollResults[i].Id)
+		}
 	}
 	allStrings := sb.String()
 	floats := []float64{}
@@ -30,7 +41,6 @@ func Translate(data forms.Form) ([]Edge, int, map[int]User) {
 	for i := 0; i < data.Participant_count; i++ {
 		floats = append(floats, HashHeuristic(data.PollResults[i].Name, allStrings))
 	}
-
 
 	graph := []Edge{}
 
@@ -53,7 +63,7 @@ func Translate(data forms.Form) ([]Edge, int, map[int]User) {
 			if cap == cap+floats[i] {
 				println("yes")
 			}
-			graph = append(graph, Edge{From: userNodeInc, To: timeslotNodeInc, Capacity: 1, Cost: cap+floats[i]})
+			graph = append(graph, Edge{From: userNodeInc, To: timeslotNodeInc, Capacity: 1, Cost: cap + floats[i]})
 			timeslotNodeInc++
 		}
 
@@ -66,4 +76,17 @@ func Translate(data forms.Form) ([]Edge, int, map[int]User) {
 		graph = append(graph, Edge{From: i, To: timeslotNodeInc, Capacity: 1, Cost: 0})
 	}
 	return graph, timeslotNodeInc, nodeToUser
+}
+
+// https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-go
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randSeq(n int) string {
+	rand.Seed(time.Now().UnixNano())
+
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
 }

--- a/src/graph/graph_translater.go
+++ b/src/graph/graph_translater.go
@@ -31,26 +31,29 @@ func Translate(data forms.Form) ([]Edge, int, map[int]User) {
 		floats = append(floats, HashHeuristic(data.PollResults[i].Name, allStrings))
 	}
 
+
 	graph := []Edge{}
 
 	// Translate participants to source linked nodes
 	for i, participant := range data.PollResults {
 		// Add edge from source to participant
-		graph = append(graph, Edge{From: 0, To: userNodeInc, Capacity: 1, Cost: 1})
+		graph = append(graph, Edge{From: 0, To: userNodeInc, Capacity: 1, Cost: 0})
 
 		// Translate timeslots to participant linked nodes
 		for _, timeslot := range participant.Votes {
 			// Add edge from participant to timeslot
-			var cap int
+			var cap float64
 			if timeslot == 0 {
-				cap = 5
+				cap = 5.0
 			} else if timeslot == 2 {
-				cap = 3
+				cap = 3.0
 			} else {
-				cap = 1
+				cap = 1.0
 			}
-
-			graph = append(graph, Edge{From: userNodeInc, To: timeslotNodeInc, Capacity: 1, Cost: cap})
+			if cap == cap+floats[i] {
+				println("yes")
+			}
+			graph = append(graph, Edge{From: userNodeInc, To: timeslotNodeInc, Capacity: 1, Cost: cap+floats[i]})
 			timeslotNodeInc++
 		}
 
@@ -60,7 +63,7 @@ func Translate(data forms.Form) ([]Edge, int, map[int]User) {
 
 	// Link timeslots to sink
 	for i := intialTimeslotNodeInc; i < timeslotNodeInc; i++ {
-		graph = append(graph, Edge{From: i, To: timeslotNodeInc, Capacity: 1, Cost: 1})
+		graph = append(graph, Edge{From: i, To: timeslotNodeInc, Capacity: 1, Cost: 0})
 	}
 	return graph, timeslotNodeInc, nodeToUser
 }

--- a/src/graph/min_cost.go
+++ b/src/graph/min_cost.go
@@ -1,6 +1,9 @@
 package graph
 
 import (
+	"hash/fnv"
+	"strconv"
+
 	"github.com/golang-collections/go-datastructures/queue"
 )
 
@@ -155,4 +158,47 @@ func MinCostPath(N, K, s, t int, edges []Edge) (int, [][]int) {
 		return cost, paths
 	}
 
+}
+
+// TODO: Figure out if this is doable with a rolling hash function
+func HashHeuristic(groupHash, FullHash string) float64 {
+	// Combine the two hash strings from input
+	combined_str := groupHash + FullHash
+
+	// convert to byte array
+	combined := []byte(combined_str)
+
+	// Create hash value of 32 bits
+	hasher := fnv.New32a()
+	hasher.Write(combined)
+	hash := hasher.Sum32()
+
+	// convert the hash to a binary string of 10 bits by shifting
+	// Then we convert the binary string to a float64 for the heuristic
+	// The binary number has 54 0s in front of it to make it a decimal number of minimal size
+	// This is to make the heuristic as small as possible to avoid messing with the flow algorithm
+	float, err := strconv.ParseFloat(binaryConvert(hash), 64)
+	if err != nil {
+		panic(err)
+	}
+
+	return float
+}
+
+func binaryConvert(n uint32) string {
+	// Shift the number to the right until it is less than 1024 to ensure it is 10 bits or less
+	for {
+		if n > 1024 {
+			n = n >> 1
+		// or shift the number to the left until it is 10 bits
+		} else if len(strconv.FormatInt(int64(n),2)) < 10 {
+			n = n << 1
+		} else {
+			break
+		}
+	}
+	// Convert the binary number to a very small decimal value with 54 0s in front
+	lead := "000000000000000000000000000000000000000000000000000000"
+
+	return lead + strconv.FormatInt(int64(n), 2)
 }


### PR DESCRIPTION
This PR includes the basic budget spreading. The idea is that all groups have a certain budget so groups that select more timeslots will have a small spread of points and thus be more likely to get the timeslots they want. Groups with few selected timeslots will have higher values on not wanted timeslots meaning you may get worse timeslots in cases over groups who are less picky. This should ensure anti game behavior as there is now an incentive to be truthful and less picky when selecting timeslots. This should help with fairness and help groups that try to be as realistic as possible with timeslot selections 

Resolves #26 